### PR TITLE
feature: support ENS subdomains

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -25,13 +25,14 @@ function parseURL(url) {
   let type = "svg"
 
   const urlParts = url.replace("/a/", "").split(".");
+  const urlPartsLen = urlParts.length
 
   // Handle ENS domains
-  if (urlParts[1] === "eth") {
-    addressFromUrl = `${urlParts[0]}.${urlParts[1]}`
-    if (urlParts[2]) {
-      type = urlParts[2];
-    }
+  if (urlPartsLen > 2 && urlParts[urlPartsLen-2] === "eth") {
+    addressFromUrl = urlParts.slice(0, urlPartsLen-1).join(".")
+    type = urlParts[urlPartsLen-1];
+  } else if (urlPartsLen > 1 && urlParts[urlParts.length-1] === "eth") {
+    addressFromUrl = urlParts.slice(0, urlPartsLen).join(".")
   } else {
     addressFromUrl = urlParts[0];
     if (urlParts[1]) {


### PR DESCRIPTION
The Ethereum Name Service allows for name owners to register for subdomains.
In that sense, both `polyphene.eth` and `thomas.polyphene.eth` are valid and registered names.
However, only the first one used to be supported by effigy.im .
This PR fixes that, implementing support for an unlimited number of subdomains.