### PR TITLE
Optimize fillRect function in blockiesPNG.js

### DIFF
--- a/functions/lib/blockiesPNG.js
+++ b/functions/lib/blockiesPNG.js
@@ -85,10 +85,10 @@ function buildOptions(opts) {
 
 // Modifies the passed PNG to fill in a specified rectangle
 function fillRect(png, x, y, w, h, color) {
-	for (let i = 0; i < w; i++) {
-		for (let j = 0; j < h; j++) {
-			png.buffer[png.index(x + i, y + j)] = color;
-		}
+	const startIndex = png.index(x, y);
+	const endIndex = png.index(x + w - 1, y + h - 1);
+	for (let i = startIndex; i <= endIndex; i++) {
+		png.buffer[i] = color;
 	}
 }
 


### PR DESCRIPTION
Fixes #35

Optimize the `fillRect` function in `functions/lib/blockiesPNG.js`.

* Use a single loop to fill the rectangle, reducing the number of iterations.
* Calculate the starting index and fill the buffer in a single pass, improving performance.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/effigy.im/pull/38?shareId=ee67ad09-770f-4b15-9f27-3802fa99c84d).