### PR TITLE
Cache ENS lookup response for a week

### DIFF
--- a/functions/__tests__/getENSAvatar.test.js
+++ b/functions/__tests__/getENSAvatar.test.js
@@ -177,7 +177,9 @@ describe("getENSAvatar", () => {
 		provider.AlchemyProvider.mockImplementationOnce(() => ({
 			lookupAddress: jest.fn().mockResolvedValue("vitalik.eth"),
 			getResolver: jest.fn().mockResolvedValue({
-				getText: jest.fn().mockResolvedValue("https://example.com/new-avatar.png"),
+				getText: jest
+					.fn()
+					.mockResolvedValue("https://example.com/new-avatar.png"),
 			}),
 		}));
 

--- a/functions/readme.md
+++ b/functions/readme.md
@@ -1,5 +1,3 @@
-
-
 This repository contains an API for generating and serving Ethereum "blockie" identicons. The identicons can be generated as SVG or PNG images. The API also supports fetching ENS (Ethereum Name Service) avatars if available for a given Ethereum address. 🌈
 
 ## Features ✨
@@ -9,6 +7,7 @@ This repository contains an API for generating and serving Ethereum "blockie" id
 - Redirect to ENS avatar URL if available
 - Customizable identicon colors and styles
 - Supports Ethereum addresses and ENS names as input
+- Caching mechanism for ENS lookup responses using Firebase Firestore
 
 ## API Endpoints 🚀
 
@@ -27,9 +26,18 @@ Where `:address` can be an Ethereum address or an ENS name. The identicon type (
 
 If an ENS avatar is available for the provided Ethereum address or ENS name, the API will redirect to the avatar URL.
 
+## Caching Mechanism 🗄️
+
+The API uses Firebase Firestore to cache ENS lookup responses. The caching mechanism works as follows:
+
+1. When an ENS lookup request is made, the API first checks the Firestore cache for a cached response.
+2. If a cached response is found and it is not older than the defined TTL (7 days), the cached response is returned.
+3. If no cached response is found or the cached response is older than the TTL, the API performs the ENS lookup and stores the response in the Firestore cache with a timestamp.
+
 ## Technologies Used 🛠️
 
 - Firebase Functions for serverless deployment
+- Firebase Firestore for caching ENS lookup responses
 - Ethers.js for interacting with the Ethereum blockchain
 - Axios for making HTTP requests
 - Various utility libraries for generating identicons and handling colors


### PR DESCRIPTION
Fixes #40

Add caching mechanism for ENS lookup responses using Firebase Firestore.

* **functions/index.js**
  - Add Firebase Firestore initialization and in-memory cache for ENS lookup responses.
  - Update `getENSAvatar` function to check both in-memory and Firestore cache before performing ENS lookup.
  - Store ENS lookup responses in both in-memory and Firestore cache with a TTL of 7 days.

* **functions/__tests__/getENSAvatar.test.js**
  - Add tests to verify caching behavior for ENS lookup responses.

* **functions/readme.md**
  - Document the caching mechanism for ENS lookup responses using Firebase Firestore.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/effigy.im/pull/41?shareId=a6b98b2f-dd3b-468c-a899-4c51e145680d).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced caching for ENS avatar retrieval, improving efficiency by storing recent lookup responses.
	- Added a section in the documentation detailing the new caching mechanism and its usage.

- **Bug Fixes**
	- Enhanced error handling for various scenarios in avatar URL resolution.

- **Documentation**
	- Updated README to include information on the caching mechanism and technologies used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->