### PR TITLE
Implement proper rate limiting for API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ To use the service in an image tag, use the following format:
 
 If an ENS avatar is available for the provided Ethereum address or ENS name, effigy.im will redirect to the avatar URL. 🌠
 
+## Rate Limits ⏳
+
+To prevent abuse, the API enforces rate limits on requests. The current rate limits are as follows:
+
+- Maximum of 100 requests per 15 minutes per IP address.
+
+If you exceed the rate limit, you will receive a `429 Too Many Requests` response. The response will include rate limiting headers to inform you of your current rate limit status.
+
 ## Repository Structure 📂
 
 The repository is organized as follows:

--- a/functions/__tests__/rateLimit.test.js
+++ b/functions/__tests__/rateLimit.test.js
@@ -1,0 +1,31 @@
+const request = require("supertest");
+const functions = require("../index");
+const express = require("express");
+
+const app = express();
+app.use("/a", functions.avatar);
+
+describe("Rate Limiting Middleware", () => {
+  test("should allow requests under the rate limit", async () => {
+    for (let i = 0; i < 100; i++) {
+      const response = await request(app).get("/a/testaddress.svg");
+      expect(response.status).not.toBe(429);
+    }
+  });
+
+  test("should block requests exceeding the rate limit", async () => {
+    for (let i = 0; i < 100; i++) {
+      await request(app).get("/a/testaddress.svg");
+    }
+    const response = await request(app).get("/a/testaddress.svg");
+    expect(response.status).toBe(429);
+    expect(response.body.error).toBe("Too many requests");
+  });
+
+  test("should include rate limiting headers in responses", async () => {
+    const response = await request(app).get("/a/testaddress.svg");
+    expect(response.headers).toHaveProperty("x-ratelimit-limit");
+    expect(response.headers).toHaveProperty("x-ratelimit-remaining");
+    expect(response.headers).toHaveProperty("x-ratelimit-reset");
+  });
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,7 +21,8 @@
 		"caip": "^1.1.1",
 		"ethers": "^6.12.0",
 		"firebase-admin": "^12.1.0",
-		"firebase-functions": "^4.9.0"
+		"firebase-functions": "^4.9.0",
+		"express-rate-limit": "^6.7.0"
 	},
 	"devDependencies": {
 		"chai": "^5.1.2",

--- a/functions/readme.md
+++ b/functions/readme.md
@@ -1,5 +1,3 @@
-
-
 This repository contains an API for generating and serving Ethereum "blockie" identicons. The identicons can be generated as SVG or PNG images. The API also supports fetching ENS (Ethereum Name Service) avatars if available for a given Ethereum address. 🌈
 
 ## Features ✨
@@ -26,6 +24,14 @@ Where `:address` can be an Ethereum address or an ENS name. The identicon type (
 ```
 
 If an ENS avatar is available for the provided Ethereum address or ENS name, the API will redirect to the avatar URL.
+
+## Rate Limits ⏳
+
+To prevent abuse, the API enforces rate limits on requests. The current rate limits are as follows:
+
+- Maximum of 100 requests per 15 minutes per IP address.
+
+If you exceed the rate limit, you will receive a `429 Too Many Requests` response. The response will include rate limiting headers to inform you of your current rate limit status.
 
 ## Technologies Used 🛠️
 


### PR DESCRIPTION
Fixes #33

Add rate limiting to the avatar endpoint to prevent abuse.

* **Add `express-rate-limit` package**:
  - Add `express-rate-limit` to dependencies in `functions/package.json`.

* **Implement rate limiting middleware**:
  - Import `express-rate-limit` in `functions/index.js`.
  - Define rate limiting middleware with a limit of 100 requests per 15 minutes per IP.
  - Apply rate limiting middleware to the avatar endpoint.
  - Add rate limiting headers to responses in the avatar endpoint.

* **Add tests for rate limiting**:
  - Add `functions/__tests__/rateLimit.test.js` to test rate limiting functionality.
  - Test for rate limiting headers in responses.

* **Update documentation**:
  - Add a section explaining the rate limits and how they are applied in `README.md` and `functions/readme.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/effigy.im/pull/42?shareId=a85ff5b6-54d0-47bd-8624-0b0bfccce145).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "Rate Limits" section in the README, detailing the API's request limits and response behavior for exceeded limits.
	- Implemented rate limiting for the avatar endpoint, restricting requests to 100 per 15 minutes per IP address.

- **Bug Fixes**
	- Enhanced error handling for the avatar endpoint to provide specific status codes and messages.

- **Tests**
	- Added a suite of tests for the rate limiting middleware to validate functionality and response behavior. 

- **Documentation**
	- Updated README and functions README to include information on rate limiting policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->